### PR TITLE
Migrate to elasticsearch 7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Plugin versions are available for (at least) all minor versions of Elasticsearch
 The first 3 digits of plugin version is Elasticsearch versioning. The last digit is used for plugin versioning under an elasticsearch version.
 
 To install it, launch this command in Elasticsearch directory replacing the url by the correct link for your Elasticsearch version (see table)
-`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.1.0.1/pathhierarchy-aggregation-7.1.0.1.zip`
+`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.1.1.0/pathhierarchy-aggregation-7.1.1.0.zip`
 
 | elasticsearch version | plugin version | plugin url |
 | --------------------- | -------------- | ---------- |
@@ -325,7 +325,7 @@ To install it, launch this command in Elasticsearch directory replacing the url 
 | 6.7.1 | 6.7.1.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.7.1.1/pathhierarchy-aggregation-6.7.1.1.zip |
 | 6.8.0 | 6.8.0.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.1/pathhierarchy-aggregation-6.8.0.1.zip |
 | 7.0.1 | 7.0.1.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.0.1.0/pathhierarchy-aggregation-7.0.1.0.zip |
-| 7.1.0 | 7.1.0.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.1.0.1/pathhierarchy-aggregation-7.1.0.1.zip |
+| 7.1.1 | 7.1.1.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.1.1.0/pathhierarchy-aggregation-7.1.1.0.zip |
 
 
 License

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Plugin versions are available for (at least) all minor versions of Elasticsearch
 The first 3 digits of plugin version is Elasticsearch versioning. The last digit is used for plugin versioning under an elasticsearch version.
 
 To install it, launch this command in Elasticsearch directory replacing the url by the correct link for your Elasticsearch version (see table)
-`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.2.0.0/pathhierarchy-aggregation-7.2.0.0.zip`
+`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.2.0.1/pathhierarchy-aggregation-7.2.0.1.zip`
 
 | elasticsearch version | plugin version | plugin url |
 | --------------------- | -------------- | ---------- |
@@ -326,7 +326,7 @@ To install it, launch this command in Elasticsearch directory replacing the url 
 | 6.8.1 | 6.8.1.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.1.1/pathhierarchy-aggregation-6.8.1.1.zip |
 | 7.0.1 | 7.0.1.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.0.1.0/pathhierarchy-aggregation-7.0.1.0.zip |
 | 7.1.1 | 7.1.1.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.1.1.0/pathhierarchy-aggregation-7.1.1.0.zip |
-| 7.2.0 | 7.2.0.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.2.0.0/pathhierarchy-aggregation-7.2.0.0.zip |
+| 7.2.0 | 7.2.0.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.2.0.1/pathhierarchy-aggregation-7.2.0.1.zip |
 
 
 License

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Plugin versions are available for (at least) all minor versions of Elasticsearch
 The first 3 digits of plugin version is Elasticsearch versioning. The last digit is used for plugin versioning under an elasticsearch version.
 
 To install it, launch this command in Elasticsearch directory replacing the url by the correct link for your Elasticsearch version (see table)
-`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.0.0.0/pathhierarchy-aggregation-7.0.0.0.zip`
+`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.1.0.0/pathhierarchy-aggregation-7.1.0.0.zip`
 
 | elasticsearch version | plugin version | plugin url |
 | --------------------- | -------------- | ---------- |
@@ -271,6 +271,7 @@ To install it, launch this command in Elasticsearch directory replacing the url 
 | 6.7.1 | 6.7.1.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.7.1.1/pathhierarchy-aggregation-6.7.1.1.zip |
 | 6.8.0 | 6.8.0.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.0/pathhierarchy-aggregation-6.8.0.0.zip |
 | 7.0.0 | 7.0.0.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.0.0.0/pathhierarchy-aggregation-7.0.0.0.zip |
+| 7.1.0 | 7.1.0.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.1.0.0/pathhierarchy-aggregation-7.1.0.0.zip |
 
 
 License

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Plugin versions are available for (at least) all minor versions of Elasticsearch
 The first 3 digits of plugin version is Elasticsearch versioning. The last digit is used for plugin versioning under an elasticsearch version.
 
 To install it, launch this command in Elasticsearch directory replacing the url by the correct link for your Elasticsearch version (see table)
-`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.1.1/pathhierarchy-aggregation-6.8.1.1.zip`
+`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.2.0/pathhierarchy-aggregation-6.8.2.0.zip`
 
 | elasticsearch version | plugin version | plugin url |
 | --------------------- | -------------- | ---------- |
@@ -323,7 +323,7 @@ To install it, launch this command in Elasticsearch directory replacing the url 
 | 6.5.4 | 6.5.4.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.5.4.1/pathhierarchy-aggregation-6.5.4.1.zip |
 | 6.6.2 | 6.6.2.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.6.2.0/pathhierarchy-aggregation-6.6.2.0.zip |
 | 6.7.1 | 6.8.0.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.1/pathhierarchy-aggregation-6.8.0.1.zip |
-| 6.8.1 | 6.8.1.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.1.1/pathhierarchy-aggregation-6.8.1.1.zip |
+| 6.8.2 | 6.8.2.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.2.0/pathhierarchy-aggregation-6.8.2.0.zip |
 
 
 License

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Plugin versions are available for (at least) all minor versions of Elasticsearch
 The first 3 digits of plugin version is Elasticsearch versioning. The last digit is used for plugin versioning under an elasticsearch version.
 
 To install it, launch this command in Elasticsearch directory replacing the url by the correct link for your Elasticsearch version (see table)
-`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.1.0.0/pathhierarchy-aggregation-7.1.0.0.zip`
+`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.1.0.1/pathhierarchy-aggregation-7.1.0.1.zip`
 
 | elasticsearch version | plugin version | plugin url |
 | --------------------- | -------------- | ---------- |
@@ -271,7 +271,7 @@ To install it, launch this command in Elasticsearch directory replacing the url 
 | 6.7.1 | 6.7.1.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.7.1.1/pathhierarchy-aggregation-6.7.1.1.zip |
 | 6.8.0 | 6.8.0.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.1/pathhierarchy-aggregation-6.8.0.1.zip |
 | 7.0.1 | 7.0.1.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.0.1.0/pathhierarchy-aggregation-7.0.1.0.zip |
-| 7.1.0 | 7.1.0.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.1.0.0/pathhierarchy-aggregation-7.1.0.0.zip |
+| 7.1.0 | 7.1.0.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.1.0.1/pathhierarchy-aggregation-7.1.0.1.zip |
 
 
 License

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ To install it, launch this command in Elasticsearch directory replacing the url 
 | 6.5.4 | 6.5.4.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.5.4.1/pathhierarchy-aggregation-6.5.4.1.zip |
 | 6.6.2 | 6.6.2.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.6.2.0/pathhierarchy-aggregation-6.6.2.0.zip |
 | 6.7.1 | 6.7.1.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.7.1.1/pathhierarchy-aggregation-6.7.1.1.zip |
+| 6.8.0 | 6.8.0.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.0/pathhierarchy-aggregation-6.8.0.0.zip |
 | 7.0.1 | 7.0.1.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.0.1.0/pathhierarchy-aggregation-7.0.1.0.zip |
 
 

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Plugin versions are available for (at least) all minor versions of Elasticsearch
 The first 3 digits of plugin version is Elasticsearch versioning. The last digit is used for plugin versioning under an elasticsearch version.
 
 To install it, launch this command in Elasticsearch directory replacing the url by the correct link for your Elasticsearch version (see table)
-`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.1.1.0/pathhierarchy-aggregation-7.1.1.0.zip`
+`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.2.0.0/pathhierarchy-aggregation-7.2.0.0.zip`
 
 | elasticsearch version | plugin version | plugin url |
 | --------------------- | -------------- | ---------- |
@@ -326,6 +326,7 @@ To install it, launch this command in Elasticsearch directory replacing the url 
 | 6.8.1 | 6.8.1.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.1.0/pathhierarchy-aggregation-6.8.1.0.zip |
 | 7.0.1 | 7.0.1.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.0.1.0/pathhierarchy-aggregation-7.0.1.0.zip |
 | 7.1.1 | 7.1.1.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.1.1.0/pathhierarchy-aggregation-7.1.1.0.zip |
+| 7.2.0 | 7.2.0.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.2.0.0/pathhierarchy-aggregation-7.2.0.0.zip |
 
 
 License

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Plugin versions are available for (at least) all minor versions of Elasticsearch
 The first 3 digits of plugin version is Elasticsearch versioning. The last digit is used for plugin versioning under an elasticsearch version.
 
 To install it, launch this command in Elasticsearch directory replacing the url by the correct link for your Elasticsearch version (see table)
-`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.7.1.1/pathhierarchy-aggregation-6.7.1.1.zip`
+`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.0/pathhierarchy-aggregation-6.8.0.0.zip`
 
 | elasticsearch version | plugin version | plugin url |
 | --------------------- | -------------- | ---------- |
@@ -268,7 +268,8 @@ To install it, launch this command in Elasticsearch directory replacing the url 
 | 6.4.3 | 6.4.3.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.4.3.0/elasticsearch-aggregation-pathhierarchy-6.4.3.0.zip |
 | 6.5.4 | 6.5.4.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.5.4.1/pathhierarchy-aggregation-6.5.4.1.zip |
 | 6.6.2 | 6.6.2.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.6.2.0/pathhierarchy-aggregation-6.6.2.0.zip |
-| 6.7.1 | 6.7.1.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.7.1.1/pathhierarchy-aggregation-6.7.1.1.zip |
+| 6.7.1 | 6.8.0.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.0/pathhierarchy-aggregation-6.8.0.0.zip |
+| 6.8.0 | 6.8.0.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.0/pathhierarchy-aggregation-6.8.0.0.zip |
 
 
 License

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Plugin versions are available for (at least) all minor versions of Elasticsearch
 The first 3 digits of plugin version is Elasticsearch versioning. The last digit is used for plugin versioning under an elasticsearch version.
 
 To install it, launch this command in Elasticsearch directory replacing the url by the correct link for your Elasticsearch version (see table)
-`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.0/pathhierarchy-aggregation-6.8.0.0.zip`
+`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.1/pathhierarchy-aggregation-6.8.0.1.zip`
 
 | elasticsearch version | plugin version | plugin url |
 | --------------------- | -------------- | ---------- |
@@ -268,8 +268,8 @@ To install it, launch this command in Elasticsearch directory replacing the url 
 | 6.4.3 | 6.4.3.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.4.3.0/elasticsearch-aggregation-pathhierarchy-6.4.3.0.zip |
 | 6.5.4 | 6.5.4.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.5.4.1/pathhierarchy-aggregation-6.5.4.1.zip |
 | 6.6.2 | 6.6.2.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.6.2.0/pathhierarchy-aggregation-6.6.2.0.zip |
-| 6.7.1 | 6.8.0.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.0/pathhierarchy-aggregation-6.8.0.0.zip |
-| 6.8.0 | 6.8.0.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.0/pathhierarchy-aggregation-6.8.0.0.zip |
+| 6.7.1 | 6.8.0.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.1/pathhierarchy-aggregation-6.8.0.1.zip |
+| 6.8.0 | 6.8.0.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.1/pathhierarchy-aggregation-6.8.0.1.zip |
 
 
 License

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Plugin versions are available for (at least) all minor versions of Elasticsearch
 The first 3 digits of plugin version is Elasticsearch versioning. The last digit is used for plugin versioning under an elasticsearch version.
 
 To install it, launch this command in Elasticsearch directory replacing the url by the correct link for your Elasticsearch version (see table)
-`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.0.1.0/pathhierarchy-aggregation-7.0.1.0.zip`
+`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.1.0.0/pathhierarchy-aggregation-7.1.0.0.zip`
 
 | elasticsearch version | plugin version | plugin url |
 | --------------------- | -------------- | ---------- |
@@ -271,6 +271,7 @@ To install it, launch this command in Elasticsearch directory replacing the url 
 | 6.7.1 | 6.7.1.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.7.1.1/pathhierarchy-aggregation-6.7.1.1.zip |
 | 6.8.0 | 6.8.0.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.0/pathhierarchy-aggregation-6.8.0.0.zip |
 | 7.0.1 | 7.0.1.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.0.1.0/pathhierarchy-aggregation-7.0.1.0.zip |
+| 7.1.0 | 7.1.0.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.1.0.0/pathhierarchy-aggregation-7.1.0.0.zip |
 
 
 License

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 Elasticsearch Aggregation Path Hierarchy Plugin
 =========================================
 
-This plugins adds the possibility to create hierarchical aggregations.
+This plugin adds the possibility to create hierarchical aggregations.
 Each term is split on a provided separator (default "/") then aggregated by level.
 For a complete example see https://github.com/elastic/elasticsearch/issues/8896
+
+Two different aggregations are available:
+ - `path_hierarchy` for hierarchical aggregations on `keywords` field or `scripts`
+ - `date_hierarchy` for hierachical aggregations on `date` fields. It is more optimized to use this aggregation for date instead of a script.
 
 This is a multi bucket aggregation.
 
@@ -14,11 +18,11 @@ Installation
 `bin/plugin --install path_hierarchy --url "https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.6.0.2/pathhierarchy-aggregation-6.6.0.2.zip"`
 
 Build
------------
+-----
 Requires Java 12
 
-Usage
------
+Path hierarchy aggregation
+--------------------------
 
 ### Parameters
 
@@ -40,44 +44,41 @@ Examples
 #### String field
 
 ```
-Add data:
+# Add data:
 
-PUT /filesystem
+PUT filesystem?include_type_name=false
 {
   "mappings": {
-    "file": {
-      "properties": {
-        "path": {
-          "type": "keyword"
-        }
+    "properties": {
+      "path": {
+        "type": "keyword"
       }
     }
   }
 }
 
-PUT /filesystem/file/1
+PUT /filesystem/_doc/1
 {
   "path": "/My documents/Spreadsheets/Budget_2013.xls",
   "views": 10
 }
 
-PUT /filesystem/file/2
+PUT /filesystem/_doc/2
 {
   "path": "/My documents/Spreadsheets/Budget_2014.xls",
   "views": 7
 }
 
-PUT /filesystem/file/3
+PUT /filesystem/_doc/3
 {
   "path": "/My documents/Test.txt",
   "views": 1
 }
 
 
+# Path hierarchy request :
 
-Path hierarchy request :
-
-GET /filesystem/file/_search?size=0
+GET /filesystem/_search?size=0
 {
   "aggs": {
     "tree": {
@@ -156,41 +157,39 @@ Result :
 
 ```
 
-PUT calendar
+PUT calendar?include_type_name=false
 {
   "mappings": {
-    "date": {
-      "properties": {
-        "date": {
-          "type": "date",
-          "index": false,
-          "doc_values": true
-        }
+    "properties": {
+      "date": {
+        "type": "date"
       }
     }
   }
 }
 
-PUT /calendar/date/1
+PUT /calendar/_doc/1
 {
   "date": "2012-01-10T02:47:28"
 }
-PUT /calendar/date/2
+PUT /calendar/_doc/2
 {
   "date": "2012-01-05T01:43:35"
 }
-PUT /calendar/date/3
+PUT /calendar/_doc/3
 {
   "date": "2012-05-01T12:24:19"
 }
 
-GET /calendar/date/_search?size=0
+GET /calendar/_search?size=0
 {
   "aggs": {
     "tree": {
       "path_hierarchy": {
-        "script": "doc['date'].value.toString('YYYY/MM/dd')",
-        "order": {"_key": "asc"}
+        "script": "doc['date'].value.toOffsetDateTime().format(DateTimeFormatter.ofPattern('yyyy/MM/dd'))",
+        "order": {
+          "_key": "asc"
+        }
       }
     }
   }
@@ -243,10 +242,65 @@ Result :
   }
 }
 
+```
 
+Date hierarchy
+--------------
+
+### Parameters
+
+ - `field` : field to aggregate on. This parameter is mandatory
+ - `interval`: date interval used to create the hierarchy. Allowed values are: `years`, `months`, `days`, `hours`, `minutes`, `seconds` Default to `years`.
+ - `order` : order parameter to define how to sort result. Allowed parameters are `_key`, `_count` or sub aggregation name. Default to {"_count": "desc}.
+ - `size`: size parameter to define how many buckets should be returned. Default to 10.
+ - `shard_size`: how many buckets returned by each shards. Set to size if smaller, default to size if the search request needs to go to a single shard, and (size * 1.5 + 10) otherwise (more information here: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#_shard_size_3).
+ - `min_doc_count`: Return buckets containing at least `min_doc_count` document. Default to 0
+
+
+Example
+-------
 
 ```
 
+PUT calendar
+{
+  "mappings": {
+    "properties": {
+      "date": {
+        "type": "date"
+      }
+    }
+  }
+}
+
+PUT /calendar/_doc/1
+{
+  "date": "2012-01-10T02:47:28"
+}
+PUT /calendar/_doc/2
+{
+  "date": "2012-01-05T01:43:35"
+}
+PUT /calendar/_doc/3
+{
+  "date": "2012-05-01T12:24:19"
+}
+
+GET /calendar/_search?size=0
+{
+  "aggs": {
+    "tree": {
+      "date_hierarchy": {
+        "interval": "days",
+        "order": {
+          "_key": "asc"
+        }
+      }
+    }
+  }
+}
+
+```
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ To install it, launch this command in Elasticsearch directory replacing the url 
 | 6.5.4 | 6.5.4.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.5.4.1/pathhierarchy-aggregation-6.5.4.1.zip |
 | 6.6.2 | 6.6.2.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.6.2.0/pathhierarchy-aggregation-6.6.2.0.zip |
 | 6.7.1 | 6.7.1.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.7.1.1/pathhierarchy-aggregation-6.7.1.1.zip |
+| 6.8.0 | 6.8.0.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.0/pathhierarchy-aggregation-6.8.0.0.zip |
 | 7.0.0 | 7.0.0.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.0.0.0/pathhierarchy-aggregation-7.0.0.0.zip |
 
 

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Plugin versions are available for (at least) all minor versions of Elasticsearch
 The first 3 digits of plugin version is Elasticsearch versioning. The last digit is used for plugin versioning under an elasticsearch version.
 
 To install it, launch this command in Elasticsearch directory replacing the url by the correct link for your Elasticsearch version (see table)
-`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.1/pathhierarchy-aggregation-6.8.0.1.zip`
+`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.1.0/pathhierarchy-aggregation-6.8.1.0.zip`
 
 | elasticsearch version | plugin version | plugin url |
 | --------------------- | -------------- | ---------- |
@@ -323,7 +323,7 @@ To install it, launch this command in Elasticsearch directory replacing the url 
 | 6.5.4 | 6.5.4.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.5.4.1/pathhierarchy-aggregation-6.5.4.1.zip |
 | 6.6.2 | 6.6.2.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.6.2.0/pathhierarchy-aggregation-6.6.2.0.zip |
 | 6.7.1 | 6.8.0.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.1/pathhierarchy-aggregation-6.8.0.1.zip |
-| 6.8.0 | 6.8.0.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.1/pathhierarchy-aggregation-6.8.0.1.zip |
+| 6.8.1 | 6.8.1.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.1.0/pathhierarchy-aggregation-6.8.1.0.zip |
 
 
 License

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Plugin versions are available for (at least) all minor versions of Elasticsearch
 The first 3 digits of plugin version is Elasticsearch versioning. The last digit is used for plugin versioning under an elasticsearch version.
 
 To install it, launch this command in Elasticsearch directory replacing the url by the correct link for your Elasticsearch version (see table)
-`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.1.0/pathhierarchy-aggregation-6.8.1.0.zip`
+`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.1.1/pathhierarchy-aggregation-6.8.1.1.zip`
 
 | elasticsearch version | plugin version | plugin url |
 | --------------------- | -------------- | ---------- |
@@ -323,7 +323,7 @@ To install it, launch this command in Elasticsearch directory replacing the url 
 | 6.5.4 | 6.5.4.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.5.4.1/pathhierarchy-aggregation-6.5.4.1.zip |
 | 6.6.2 | 6.6.2.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.6.2.0/pathhierarchy-aggregation-6.6.2.0.zip |
 | 6.7.1 | 6.8.0.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.0.1/pathhierarchy-aggregation-6.8.0.1.zip |
-| 6.8.1 | 6.8.1.0 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.1.0/pathhierarchy-aggregation-6.8.1.0.zip |
+| 6.8.1 | 6.8.1.1 | https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v6.8.1.1/pathhierarchy-aggregation-6.8.1.1.zip |
 
 
 License

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-es_version = 6.8.0
-plugin_version = 6.8.0.1
+es_version = 6.8.1
+plugin_version = 6.8.1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-es_version = 7.1.1
-plugin_version = 7.1.1.0
+es_version = 7.2.0
+plugin_version = 7.2.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-es_version = 7.0.1
-plugin_version = 7.0.1.0
+es_version = 7.1.0
+plugin_version = 7.1.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-es_version = 7.1.0
-plugin_version = 7.1.0.1
+es_version = 7.1.1
+plugin_version = 7.1.1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 es_version = 6.8.0
-plugin_version = 6.8.0.0
+plugin_version = 6.8.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 es_version = 7.1.0
-plugin_version = 7.1.0.0
+plugin_version = 7.1.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-es_version = 7.0.0
-plugin_version = 7.0.0.0
+es_version = 7.1.0
+plugin_version = 7.1.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 es_version = 7.2.0
-plugin_version = 7.2.0.0
+plugin_version = 7.2.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-es_version = 6.8.1
-plugin_version = 6.8.1.1
+es_version = 6.8.2
+plugin_version = 6.8.2.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 es_version = 6.8.1
-plugin_version = 6.8.1.0
+plugin_version = 6.8.1.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-es_version = 7.2.0
-plugin_version = 7.2.0.1
+es_version = 7.4.0
+plugin_version = 7.4.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-es_version = 6.7.1
-plugin_version = 6.7.1.1
+es_version = 6.8.0
+plugin_version = 6.8.0.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Oct 02 17:45:26 CEST 2019
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -125,8 +125,8 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin ; then
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
     JAVACMD=`cygpath --unix "$JAVACMD"`

--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem      https://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/opendatasoft/elasticsearch/plugin/PathHierarchyAggregation.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/plugin/PathHierarchyAggregation.java
@@ -4,7 +4,9 @@ import java.util.ArrayList;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.opendatasoft.elasticsearch.search.aggregations.bucket.PathHierarchyAggregationBuilder;
+import org.opendatasoft.elasticsearch.search.aggregations.bucket.DateHierarchyAggregationBuilder;
 import org.opendatasoft.elasticsearch.search.aggregations.bucket.InternalPathHierarchy;
+import org.opendatasoft.elasticsearch.search.aggregations.bucket.InternalDateHierarchy;
 
 public class PathHierarchyAggregation extends Plugin implements SearchPlugin {
     @Override
@@ -17,6 +19,14 @@ public class PathHierarchyAggregation extends Plugin implements SearchPlugin {
                         PathHierarchyAggregationBuilder::new,
                         PathHierarchyAggregationBuilder::parse)
                 .addResultReader(InternalPathHierarchy::new)
+        );
+
+        r.add(
+                new AggregationSpec(
+                        DateHierarchyAggregationBuilder.NAME,
+                        DateHierarchyAggregationBuilder::new,
+                        DateHierarchyAggregationBuilder::parse)
+                        .addResultReader(InternalDateHierarchy::new)
         );
 
         return r;

--- a/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregationBuilder.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregationBuilder.java
@@ -173,9 +173,7 @@ public class DateHierarchyAggregationBuilder extends ValuesSourceAggregationBuil
         minDocCount = in.readVLong();
         interval = in.readString();
         order = InternalOrder.Streams.readOrder(in);
-        if (in.readBoolean()) {
-            timeZone = DateTimeZone.forID(in.readString());
-        }
+        timeZone = in.readOptionalZoneId();
     }
 
     private DateHierarchyAggregationBuilder(DateHierarchyAggregationBuilder clone, Builder factoriesBuilder,
@@ -202,9 +200,7 @@ public class DateHierarchyAggregationBuilder extends ValuesSourceAggregationBuil
         order.writeTo(out);
         boolean hasTimeZone = timeZone != null;
         out.writeBoolean(hasTimeZone);
-        if (hasTimeZone) {
-            out.writeString(timeZone.getID());
-        }
+        out.writeOptionalZoneId(timeZone);
     }
 
     /**

--- a/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregationBuilder.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregationBuilder.java
@@ -171,6 +171,9 @@ public class DateHierarchyAggregationBuilder extends ValuesSourceAggregationBuil
         minDocCount = in.readVLong();
         interval = in.readString();
         order = InternalOrder.Streams.readOrder(in);
+        if (in.readBoolean()) {
+            timeZone = DateTimeZone.forID(in.readString());
+        }
     }
 
     private DateHierarchyAggregationBuilder(DateHierarchyAggregationBuilder clone, Builder factoriesBuilder,
@@ -195,6 +198,11 @@ public class DateHierarchyAggregationBuilder extends ValuesSourceAggregationBuil
         out.writeVLong(minDocCount);
         out.writeString(interval);
         order.writeTo(out);
+        boolean hasTimeZone = timeZone != null;
+        out.writeBoolean(hasTimeZone);
+        if (hasTimeZone) {
+            out.writeString(timeZone.getID());
+        }
     }
 
     /**
@@ -353,7 +361,7 @@ public class DateHierarchyAggregationBuilder extends ValuesSourceAggregationBuil
      */
     @Override
     protected int innerHashCode() {
-        return Objects.hash(interval, order, minDocCount, bucketCountThresholds);
+        return Objects.hash(interval, order, minDocCount, bucketCountThresholds, timeZone);
     }
 
     @Override
@@ -362,7 +370,8 @@ public class DateHierarchyAggregationBuilder extends ValuesSourceAggregationBuil
         return Objects.equals(interval, other.interval)
                 && Objects.equals(order, other.order)
                 && Objects.equals(minDocCount, other.minDocCount)
-                && Objects.equals(bucketCountThresholds, other.bucketCountThresholds);
+                && Objects.equals(bucketCountThresholds, other.bucketCountThresholds)
+                && Objects.equals(timeZone, other.timeZone);
     }
 
     @Override

--- a/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregationBuilder.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregationBuilder.java
@@ -1,5 +1,6 @@
 package org.opendatasoft.elasticsearch.search.aggregations.bucket;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Rounding;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -159,7 +160,7 @@ public class DateHierarchyAggregationBuilder extends ValuesSourceAggregationBuil
     }
 
     @Override
-    protected boolean serializeTargetValueType() {
+    protected boolean serializeTargetValueType(Version version) {
         return true;
     }
 
@@ -327,10 +328,10 @@ public class DateHierarchyAggregationBuilder extends ValuesSourceAggregationBuil
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory<ValuesSource.Numeric, ?> innerBuild(
+    protected ValuesSourceAggregatorFactory<ValuesSource.Numeric> innerBuild(
             SearchContext context,
             ValuesSourceConfig<ValuesSource.Numeric> config,
-            AggregatorFactory<?> parent,
+            AggregatorFactory parent,
             Builder subFactoriesBuilder) throws IOException {
 
         final List<RoundingInfo> roundingsInfo = buildRoundings();
@@ -358,12 +359,12 @@ public class DateHierarchyAggregationBuilder extends ValuesSourceAggregationBuil
      * Used for caching requests, amongst other things.
      */
     @Override
-    protected int innerHashCode() {
+    public int hashCode() {
         return Objects.hash(interval, order, minDocCount, bucketCountThresholds, timeZone);
     }
 
     @Override
-    protected boolean innerEquals(Object obj) {
+    public boolean equals(Object obj) {
         DateHierarchyAggregationBuilder other = (DateHierarchyAggregationBuilder) obj;
         return Objects.equals(interval, other.interval)
                 && Objects.equals(order, other.order)

--- a/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregationBuilder.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregationBuilder.java
@@ -1,0 +1,375 @@
+package org.opendatasoft.elasticsearch.search.aggregations.bucket;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Rounding;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.BucketOrder;
+import org.elasticsearch.search.aggregations.InternalOrder;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketAggregationBuilder;
+import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValueType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
+import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParserHelper;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static java.util.Collections.unmodifiableMap;
+
+
+/**
+ * The builder of the aggregatorFactory. Also implements the parsing of the request.
+ */
+public class DateHierarchyAggregationBuilder extends ValuesSourceAggregationBuilder<ValuesSource.Numeric, DateHierarchyAggregationBuilder>
+        implements MultiBucketAggregationBuilder {
+    public static final String NAME = "date_hierarchy";
+
+
+    public static final ParseField INTERVAL_FIELD = new ParseField("interval");
+    public static final ParseField ORDER_FIELD = new ParseField("order");
+    public static final ParseField SIZE_FIELD = new ParseField("size");
+    public static final ParseField SHARD_SIZE_FIELD = new ParseField("shard_size");
+    public static final ParseField MIN_DOC_COUNT_FIELD = new ParseField("min_doc_count");
+
+
+    public static final Map<String, IntervalConfig> INTERVAL_CONFIG;
+    static {
+        Map<String, IntervalConfig> dateFieldUnits = new LinkedHashMap<>();
+        dateFieldUnits.put("years", new IntervalConfig(Rounding.DateTimeUnit.YEAR_OF_CENTURY, "yyyy"));
+        dateFieldUnits.put("months", new IntervalConfig(Rounding.DateTimeUnit.MONTH_OF_YEAR, "MM"));
+        dateFieldUnits.put("days", new IntervalConfig(Rounding.DateTimeUnit.DAY_OF_MONTH, "dd"));
+        dateFieldUnits.put("hours", new IntervalConfig(Rounding.DateTimeUnit.HOUR_OF_DAY, "hh"));
+        dateFieldUnits.put("minutes", new IntervalConfig(Rounding.DateTimeUnit.MINUTES_OF_HOUR, "mm"));
+        dateFieldUnits.put("seconds", new IntervalConfig(Rounding.DateTimeUnit.SECOND_OF_MINUTE, "ss"));
+        INTERVAL_CONFIG = unmodifiableMap(dateFieldUnits);
+    }
+
+    public static class IntervalConfig {
+        final Rounding.DateTimeUnit dateTimeUnit;
+        final String format;
+
+        public IntervalConfig(Rounding.DateTimeUnit dateTimeUnit, String format) {
+            this.dateTimeUnit = dateTimeUnit;
+            this.format = format;
+        }
+    }
+
+    public List<RoundingInfo> buildRoundings() {
+        List<RoundingInfo> roundings = new ArrayList<>();
+
+        ZoneId timeZone = timeZone() == null ? ZoneOffset.UTC: timeZone();
+
+        for (String interval: INTERVAL_CONFIG.keySet()) {
+            roundings.add(new RoundingInfo(interval, createRounding(INTERVAL_CONFIG.get(interval).dateTimeUnit),
+                    new DocValueFormat.DateTime(DateFormatter.forPattern(INTERVAL_CONFIG.get(interval).format), timeZone,
+                            DateFieldMapper.Resolution.MILLISECONDS)));
+            if (interval.equals(interval())) {
+                break;
+            }
+        }
+
+        return roundings;
+    }
+
+    public static class RoundingInfo implements Writeable {
+        final DocValueFormat format;
+        final Rounding rounding;
+        final String interval;
+
+        public RoundingInfo(String interval, Rounding rounding, DocValueFormat docValueFormat) {
+            this.interval = interval;
+            this.rounding =  rounding;
+            this.format = docValueFormat;
+        }
+
+        public RoundingInfo(StreamInput in) throws IOException {
+            rounding = Rounding.read(in);
+            interval = in.readString();
+            format = in.readNamedWriteable(DocValueFormat.class);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            rounding.writeTo(out);
+            out.writeString(interval);
+            out.writeNamedWriteable(format);
+        }
+    }
+
+    public static final DateHierarchyAggregator.BucketCountThresholds DEFAULT_BUCKET_COUNT_THRESHOLDS = new
+            DateHierarchyAggregator.BucketCountThresholds(10, -1);
+    private static final ObjectParser<DateHierarchyAggregationBuilder, Void> PARSER;
+    static {
+
+        PARSER = new ObjectParser<>(DateHierarchyAggregationBuilder.NAME);
+        ValuesSourceParserHelper.declareNumericFields(PARSER, true, true, true);
+
+        PARSER.declareString(DateHierarchyAggregationBuilder::interval, INTERVAL_FIELD);
+
+        PARSER.declareField(DateHierarchyAggregationBuilder::timeZone, p -> {
+            if (p.currentToken() == XContentParser.Token.VALUE_STRING) {
+                return ZoneId.of(p.text());
+            } else {
+                return ZoneOffset.ofHours(p.intValue());
+            }
+        }, new ParseField("time_zone"), ObjectParser.ValueType.LONG);
+
+        PARSER.declareInt(DateHierarchyAggregationBuilder::size, SIZE_FIELD);
+        PARSER.declareLong(DateHierarchyAggregationBuilder::minDocCount, MIN_DOC_COUNT_FIELD);
+        PARSER.declareInt(DateHierarchyAggregationBuilder::shardSize, SHARD_SIZE_FIELD);
+        PARSER.declareObjectArray(DateHierarchyAggregationBuilder::order, (p, c) -> InternalOrder.Parser.parseOrderParam(p),
+                ORDER_FIELD);
+    }
+
+    public static AggregationBuilder parse(String aggregationName, XContentParser parser) throws IOException {
+        return PARSER.parse(parser, new DateHierarchyAggregationBuilder(aggregationName, null), null);
+    }
+
+    private long minDocCount = 0;
+    private ZoneId timeZone = null;
+    private String interval = "years";
+    private BucketOrder order = BucketOrder.compound(BucketOrder.count(false)); // automatically adds tie-breaker key asc order
+    private DateHierarchyAggregator.BucketCountThresholds bucketCountThresholds = new DateHierarchyAggregator.BucketCountThresholds(
+            DEFAULT_BUCKET_COUNT_THRESHOLDS);
+
+
+    private DateHierarchyAggregationBuilder(String name, ValueType valueType) {
+        super(name, ValuesSourceType.ANY, valueType);
+    }
+
+    @Override
+    protected boolean serializeTargetValueType() {
+        return true;
+    }
+
+    /**
+     * Read from a stream
+     *
+     */
+    public DateHierarchyAggregationBuilder(StreamInput in) throws IOException {
+        super(in, ValuesSourceType.ANY);
+        bucketCountThresholds = new DateHierarchyAggregator.BucketCountThresholds(in);
+        minDocCount = in.readVLong();
+        interval = in.readString();
+        order = InternalOrder.Streams.readOrder(in);
+    }
+
+    private DateHierarchyAggregationBuilder(DateHierarchyAggregationBuilder clone, Builder factoriesBuilder,
+                                            Map<String, Object> metaData) {
+        super(clone, factoriesBuilder, metaData);
+        order = clone.order;
+        minDocCount = clone.minDocCount;
+        this.bucketCountThresholds = new DateHierarchyAggregator.BucketCountThresholds(clone.bucketCountThresholds);
+    }
+
+    @Override
+    protected AggregationBuilder shallowCopy(Builder factoriesBuilder, Map<String, Object> metaData) {
+        return new DateHierarchyAggregationBuilder(this, factoriesBuilder, metaData);
+    }
+
+    /**
+     * Write to a stream
+     */
+    @Override
+    protected void innerWriteTo(StreamOutput out) throws IOException {
+        bucketCountThresholds.writeTo(out);
+        out.writeVLong(minDocCount);
+        out.writeString(interval);
+        order.writeTo(out);
+    }
+
+    /**
+     * Returns the date interval that is set on this source
+     **/
+    public String interval() {
+        return interval;
+    }
+
+    public DateHierarchyAggregationBuilder interval(String interval) {
+
+        if (INTERVAL_CONFIG.get(interval) == null) {
+            throw new IllegalArgumentException("[interval] is invalid");
+        }
+
+        this.interval = interval;
+        return this;
+    }
+
+    /**
+     * Sets the time zone to use for this aggregation
+     */
+    public DateHierarchyAggregationBuilder timeZone(ZoneId timeZone) {
+        if (timeZone == null) {
+            throw new IllegalArgumentException("[timeZone] must not be null: [" + name + "]");
+        }
+        this.timeZone = timeZone;
+        return this;
+    }
+
+    /**
+     * Gets the time zone to use for this aggregation
+     */
+    public ZoneId timeZone() {
+        return timeZone;
+    }
+
+    private Rounding createRounding(Rounding.DateTimeUnit dateTimeUnit) {
+        Rounding.Builder tzRoundingBuilder;
+        tzRoundingBuilder = Rounding.builder(dateTimeUnit);
+
+        if (timeZone() != null) {
+            tzRoundingBuilder.timeZone(timeZone());
+        }
+        Rounding rounding = tzRoundingBuilder.build();
+        return rounding;
+    }
+
+    /** Set the order in which the buckets will be returned. It returns the builder so that calls
+     *  can be chained. A tie-breaker may be added to avoid non-deterministic ordering. */
+    private DateHierarchyAggregationBuilder order(BucketOrder order) {
+        if (order == null) {
+            throw new IllegalArgumentException("[order] must not be null: [" + name + "]");
+        }
+        if(order instanceof InternalOrder.CompoundOrder || InternalOrder.isKeyOrder(order)) {
+            this.order = order; // if order already contains a tie-breaker we are good to go
+        } else { // otherwise add a tie-breaker by using a compound order
+            this.order = BucketOrder.compound(order);
+        }
+        return this;
+    }
+
+    private DateHierarchyAggregationBuilder order(List<BucketOrder> orders) {
+        if (orders == null) {
+            throw new IllegalArgumentException("[orders] must not be null: [" + name + "]");
+        }
+        // if the list only contains one order use that to avoid inconsistent xcontent
+        order(orders.size() > 1 ? BucketOrder.compound(orders) : orders.get(0));
+        return this;
+    }
+
+
+    /**
+     * Sets the size - indicating how many term buckets should be returned
+     * (defaults to 10)
+     */
+    public DateHierarchyAggregationBuilder size(int size) {
+        if (size <= 0) {
+            throw new IllegalArgumentException("[size] must be greater than 0. Found [" + size + "] in [" + name + "]");
+        }
+        bucketCountThresholds.setRequiredSize(size);
+        return this;
+    }
+
+    /** Set the minimum count of matching documents that buckets need to have
+     *  and return this builder so that calls can be chained. */
+    public DateHierarchyAggregationBuilder minDocCount(long minDocCount) {
+        if (minDocCount < 0) {
+            throw new IllegalArgumentException(
+                    "[minDocCount] must be greater than or equal to 0. Found [" + minDocCount + "] in [" + name + "]");
+        }
+        this.minDocCount = minDocCount;
+        return this;
+    }
+
+    /**
+     * Returns the number of term buckets currently configured
+     */
+    public int size() {
+        return bucketCountThresholds.getRequiredSize();
+    }
+
+
+    /**
+     * Sets the shard_size - indicating the number of term buckets each shard
+     * will return to the coordinating node (the node that coordinates the
+     * search execution). The higher the shard size is, the more accurate the
+     * results are.
+     */
+    public DateHierarchyAggregationBuilder shardSize(int shardSize) {
+        if (shardSize <= 0) {
+            throw new IllegalArgumentException(
+                    "[shardSize] must be greater than 0. Found [" + shardSize + "] in [" + name + "]");
+        }
+        bucketCountThresholds.setShardSize(shardSize);
+        return this;
+    }
+
+    /**
+     * Returns the number of term buckets per shard that are currently configured
+     */
+    public int shardSize() {
+        return bucketCountThresholds.getShardSize();
+    }
+
+    @Override
+    protected ValuesSourceAggregatorFactory<ValuesSource.Numeric, ?> innerBuild(
+            SearchContext context,
+            ValuesSourceConfig<ValuesSource.Numeric> config,
+            AggregatorFactory<?> parent,
+            Builder subFactoriesBuilder) throws IOException {
+
+        final List<RoundingInfo> roundingsInfo = buildRoundings();
+
+        return new DateHierarchyAggregatorFactory(
+                name, config, order, roundingsInfo, minDocCount, bucketCountThresholds,
+                context, parent, subFactoriesBuilder, metaData);
+    }
+
+    @Override
+    protected XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+
+        if (order != null) {
+            builder.field(ORDER_FIELD.getPreferredName());
+            order.toXContent(builder, params);
+        }
+
+        builder.field(MIN_DOC_COUNT_FIELD.getPreferredName(), minDocCount);
+
+        return builder.endObject();
+    }
+
+    /**
+     * Used for caching requests, amongst other things.
+     */
+    @Override
+    protected int innerHashCode() {
+        return Objects.hash(interval, order, minDocCount, bucketCountThresholds);
+    }
+
+    @Override
+    protected boolean innerEquals(Object obj) {
+        DateHierarchyAggregationBuilder other = (DateHierarchyAggregationBuilder) obj;
+        return Objects.equals(interval, other.interval)
+                && Objects.equals(order, other.order)
+                && Objects.equals(minDocCount, other.minDocCount)
+                && Objects.equals(bucketCountThresholds, other.bucketCountThresholds);
+    }
+
+    @Override
+    public String getType() {
+        return NAME;
+    }
+}
+

--- a/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregator.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregator.java
@@ -1,0 +1,259 @@
+package org.opendatasoft.elasticsearch.search.aggregations.bucket;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.util.LongHash;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.BucketOrder;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalOrder;
+import org.elasticsearch.search.aggregations.LeafBucketCollector;
+import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
+import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+
+public class DateHierarchyAggregator extends BucketsAggregator {
+
+    public static class BucketCountThresholds implements Writeable, ToXContentFragment {
+        private int requiredSize;
+        private int shardSize;
+
+        public BucketCountThresholds(int requiredSize, int shardSize) {
+            this.requiredSize = requiredSize;
+            this.shardSize = shardSize;
+        }
+
+        /**
+         * Read from a stream.
+         */
+        public BucketCountThresholds(StreamInput in) throws IOException {
+            requiredSize = in.readInt();
+            shardSize = in.readInt();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeInt(requiredSize);
+            out.writeInt(shardSize);
+        }
+
+        public BucketCountThresholds(DateHierarchyAggregator.BucketCountThresholds bucketCountThresholds) {
+            this(bucketCountThresholds.requiredSize, bucketCountThresholds.shardSize);
+        }
+
+        public void ensureValidity() {
+            // shard_size cannot be smaller than size as we need to at least fetch size entries from every shards in order to return size
+            if (shardSize < requiredSize) {
+                setShardSize(requiredSize);
+            }
+
+            if (requiredSize <= 0 || shardSize <= 0) {
+                throw new ElasticsearchException("parameters [required_size] and [shard_size] must be >0 in path-hierarchy aggregation.");
+            }
+        }
+
+        public int getRequiredSize() {
+            return requiredSize;
+        }
+
+        public void setRequiredSize(int requiredSize) {
+            this.requiredSize = requiredSize;
+        }
+
+        public int getShardSize() {
+            return shardSize;
+        }
+
+        public void setShardSize(int shardSize) {
+            this.shardSize = shardSize;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.field(DateHierarchyAggregationBuilder.SIZE_FIELD.getPreferredName(), requiredSize);
+            if (shardSize != -1) {
+                builder.field(DateHierarchyAggregationBuilder.SHARD_SIZE_FIELD.getPreferredName(), shardSize);
+            }
+            return builder;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(requiredSize, shardSize);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            DateHierarchyAggregator.BucketCountThresholds other = (DateHierarchyAggregator.BucketCountThresholds) obj;
+            return Objects.equals(requiredSize, other.requiredSize)
+                    && Objects.equals(shardSize, other.shardSize);
+        }
+    }
+
+    private final ValuesSource.Numeric valuesSource;
+    private final LongHash bucketOrds;
+    private final BucketOrder order;
+    private final long minDocCount;
+    private final BucketCountThresholds bucketCountThresholds;
+    private final List<DateHierarchyAggregationBuilder.RoundingInfo> roundingsInfo;
+
+    public DateHierarchyAggregator(
+            String name,
+            AggregatorFactories factories,
+            SearchContext context,
+            ValuesSource.Numeric valuesSource,
+            BucketOrder order,
+            long minDocCount,
+            BucketCountThresholds bucketCountThresholds,
+            List<DateHierarchyAggregationBuilder.RoundingInfo> roundingsInfo, SearchContext aggregationContext,
+            Aggregator parent,
+            List<PipelineAggregator> pipelineAggregators,
+            Map<String, Object> metaData
+    ) throws IOException {
+        super(name, factories, context, parent, pipelineAggregators, metaData);
+        this.valuesSource = valuesSource;
+        this.roundingsInfo = roundingsInfo;
+        this.minDocCount = minDocCount;
+        bucketOrds =  new LongHash(1, aggregationContext.bigArrays());
+        this.order = InternalOrder.validate(order, this);
+        this.bucketCountThresholds = bucketCountThresholds;
+    }
+
+    /**
+     * The collector collects the docs, including or not some score (depending of the including of a Scorer) in the
+     * collect() process.
+     *
+     * The LeafBucketCollector is a "Per-leaf bucket collector". It collects docs for the account of buckets.
+     */
+    @Override
+    public LeafBucketCollector getLeafCollector(LeafReaderContext ctx, LeafBucketCollector sub) throws IOException {
+        if (valuesSource == null) {
+            return LeafBucketCollector.NO_OP_COLLECTOR;
+        }
+        final SortedNumericDocValues values = valuesSource.longValues(ctx);
+        return new LeafBucketCollectorBase(sub, values) {
+
+            @Override
+            public void collect(int doc, long bucket) throws IOException {
+                assert bucket == 0;
+                if (values.advanceExact(doc)) {
+                    final int valuesCount = values.docValueCount();
+
+                    for (int i = 0; i < valuesCount; ++i) {
+                        long value = values.nextValue();
+                        long previousRounded = Long.MIN_VALUE;
+                        for (DateHierarchyAggregationBuilder.RoundingInfo roundingInfo: roundingsInfo) {
+                            long roundedValue = roundingInfo.rounding.round(value);
+                            // A little hacky: Add a microsecond to avoid collision between min dates interval
+                            // Since interval cannot be set to microsecond, it is not a problem
+                            if (roundedValue == previousRounded) {
+                                roundedValue += 1;
+                            }
+                            previousRounded = roundedValue;
+                            long bucketOrd = bucketOrds.add(roundedValue);
+                            if (bucketOrd < 0) { // already seen
+                                bucketOrd = -1 - bucketOrd;
+                                collectExistingBucket(sub, doc, bucketOrd);
+                            } else {
+                                collectBucket(sub, doc, bucketOrd);
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    @Override
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) throws IOException {
+        assert owningBucketOrdinal == 0;
+
+        // build buckets and store them sorted
+        final int size = (int) Math.min(bucketOrds.size(), bucketCountThresholds.getShardSize());
+
+        PathSortedTree<Long, InternalDateHierarchy.InternalBucket> pathSortedTree = new PathSortedTree<>(order.comparator(this), size);
+
+        InternalDateHierarchy.InternalBucket spare = null;
+        for (int i = 0; i < bucketOrds.size(); i++) {
+            spare = new InternalDateHierarchy.InternalBucket(0, null, 0, 0, null, null);
+
+            List<Long> paths = new ArrayList<>();
+
+            long value = bucketOrds.get(i);
+            // FIXME: find a clever and most optimized way to not recompute rounding here
+            long previousRounded = Long.MIN_VALUE;
+            for (DateHierarchyAggregationBuilder.RoundingInfo roundingInfo: roundingsInfo) {
+                long roundedValue = roundingInfo.rounding.round(value);
+                if (roundedValue == previousRounded) {
+                    roundedValue += 1;
+                }
+                previousRounded = roundedValue;
+                if (roundedValue == value) {
+                    break;
+                }
+                paths.add(roundedValue);
+            }
+
+            paths.add(value);
+
+            spare.key = value;
+            spare.aggregations = bucketAggregations(i);
+            spare.docCount = bucketDocCount(i);
+            spare.level = paths.size() - 1;
+            spare.paths = paths.toArray(new Long[0]);
+            spare.format = roundingsInfo.get(spare.level).format;
+
+            pathSortedTree.add(spare.paths, spare);
+
+            consumeBucketsAndMaybeBreak(1);
+        }
+
+        // Get the top buckets
+        final List<InternalDateHierarchy.InternalBucket> list = new ArrayList<>(size);
+        long otherHierarchyNodes = pathSortedTree.getFullSize();
+        Iterator<InternalDateHierarchy.InternalBucket> iterator = pathSortedTree.consumer();
+        for (int i = 0; i < size; i++) {
+            final InternalDateHierarchy.InternalBucket bucket = iterator.next();
+            list.add(bucket);
+            otherHierarchyNodes -= 1;
+        }
+
+        return new InternalDateHierarchy(name, list, order, minDocCount, bucketCountThresholds.getRequiredSize(),
+                bucketCountThresholds.getShardSize(), otherHierarchyNodes, pipelineAggregators(), metaData());
+    }
+
+    @Override
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalDateHierarchy(name, null, order, minDocCount, bucketCountThresholds.getRequiredSize(),
+                bucketCountThresholds.getShardSize(), 0, pipelineAggregators(), metaData());
+    }
+
+    @Override
+    protected void doClose() {
+        Releasables.close(bucketOrds);
+    }
+}

--- a/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregatorFactory.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregatorFactory.java
@@ -1,0 +1,94 @@
+package org.opendatasoft.elasticsearch.search.aggregations.bucket;
+
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.BucketOrder;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalOrder;
+import org.elasticsearch.search.aggregations.NonCollectingAggregator;
+import org.elasticsearch.search.aggregations.bucket.BucketUtils;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The factory of aggregators.
+ * ValuesSourceAggregatorFactory extends {@link AggregatorFactory}
+ */
+class DateHierarchyAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Numeric, DateHierarchyAggregatorFactory> {
+
+    private long minDocCount;
+    private BucketOrder order;
+    private List<DateHierarchyAggregationBuilder.RoundingInfo> roundingsInfo;
+    private final DateHierarchyAggregator.BucketCountThresholds bucketCountThresholds;
+
+    DateHierarchyAggregatorFactory(String name,
+                                   ValuesSourceConfig<ValuesSource.Numeric> config,
+                                   BucketOrder order,
+                                   List<DateHierarchyAggregationBuilder.RoundingInfo> roundingsInfo,
+                                   long minDocCount,
+                                   DateHierarchyAggregator.BucketCountThresholds bucketCountThresholds,
+                                   SearchContext context,
+                                   AggregatorFactory<?> parent,
+                                   AggregatorFactories.Builder subFactoriesBuilder,
+                                   Map<String, Object> metaData
+    ) throws IOException {
+        super(name, config, context, parent, subFactoriesBuilder, metaData);
+        this.order = order;
+        this.roundingsInfo = roundingsInfo;
+        this.minDocCount = minDocCount;
+        this.bucketCountThresholds = bucketCountThresholds;
+    }
+
+    @Override
+    protected Aggregator createUnmapped(
+            Aggregator parent,
+            List<PipelineAggregator> pipelineAggregators,
+            Map<String,
+            Object> metaData) throws IOException {
+        final InternalAggregation aggregation = new InternalDateHierarchy(name, new ArrayList<>(), order, minDocCount,
+                bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getShardSize(), 0, pipelineAggregators, metaData);
+        return new NonCollectingAggregator(name, context, parent, factories, pipelineAggregators, metaData) {
+            {
+                // even in the case of an unmapped aggregator, validate the
+                // order
+                InternalOrder.validate(order, this);
+            }
+
+            @Override
+            public InternalAggregation buildEmptyAggregation() { return aggregation; }
+        };
+    }
+
+    @Override
+    protected Aggregator doCreateInternal(
+            ValuesSource.Numeric valuesSource, Aggregator parent,
+            boolean collectsFromSingleBucket, List<PipelineAggregator> pipelineAggregators,
+            Map<String, Object> metaData) throws IOException {
+
+        DateHierarchyAggregator.BucketCountThresholds bucketCountThresholds = new
+                DateHierarchyAggregator.BucketCountThresholds(this.bucketCountThresholds);
+        if (!InternalOrder.isKeyOrder(order)
+                && bucketCountThresholds.getShardSize() == DateHierarchyAggregationBuilder.DEFAULT_BUCKET_COUNT_THRESHOLDS.getShardSize()) {
+            // The user has not made a shardSize selection. Use default
+            // heuristic to avoid any wrong-ranking caused by distributed
+            // counting
+            bucketCountThresholds.setShardSize(BucketUtils.suggestShardSideQueueSize(bucketCountThresholds.getRequiredSize()));
+        }
+        bucketCountThresholds.ensureValidity();
+        return new DateHierarchyAggregator(
+                name, factories, context,
+                valuesSource, order, minDocCount, bucketCountThresholds, roundingsInfo,
+                context, parent, pipelineAggregators, metaData);
+    }
+
+}
+

--- a/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregatorFactory.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregatorFactory.java
@@ -23,7 +23,7 @@ import java.util.Map;
  * The factory of aggregators.
  * ValuesSourceAggregatorFactory extends {@link AggregatorFactory}
  */
-class DateHierarchyAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Numeric, DateHierarchyAggregatorFactory> {
+class DateHierarchyAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Numeric> {
 
     private long minDocCount;
     private BucketOrder order;
@@ -37,7 +37,7 @@ class DateHierarchyAggregatorFactory extends ValuesSourceAggregatorFactory<Value
                                    long minDocCount,
                                    DateHierarchyAggregator.BucketCountThresholds bucketCountThresholds,
                                    SearchContext context,
-                                   AggregatorFactory<?> parent,
+                                   AggregatorFactory parent,
                                    AggregatorFactories.Builder subFactoriesBuilder,
                                    Map<String, Object> metaData
     ) throws IOException {

--- a/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/InternalDateHierarchy.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/InternalDateHierarchy.java
@@ -1,0 +1,340 @@
+package org.opendatasoft.elasticsearch.search.aggregations.bucket;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.BucketOrder;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
+import org.elasticsearch.search.aggregations.InternalOrder;
+import org.elasticsearch.search.aggregations.KeyComparable;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * An internal implementation of {@link InternalMultiBucketAggregation}
+ * which extends {@link org.elasticsearch.search.aggregations.Aggregation}.
+ * Mainly, returns the builder and makes the reduce of buckets.
+ */
+public class InternalDateHierarchy extends InternalMultiBucketAggregation<InternalDateHierarchy,
+        InternalDateHierarchy.InternalBucket> implements MultiBucketAggregationBuilder {
+
+    /**
+     * The bucket class of InternalDateHierarchy.
+     * @see MultiBucketsAggregation.Bucket
+     */
+    public static class InternalBucket extends InternalMultiBucketAggregation.InternalBucket implements
+            MultiBucketsAggregation.Bucket, KeyComparable<InternalBucket> {
+
+        long key;
+        protected Long[] paths;
+        protected long docCount;
+        protected InternalAggregations aggregations;
+        protected int level;
+        protected DocValueFormat format;
+
+        public InternalBucket(long docCount, InternalAggregations aggregations, long key, int level, Long[] paths, DocValueFormat format) {
+            this.key = key;
+            this.docCount = docCount;
+            this.aggregations = aggregations;
+            this.level = level;
+            this.paths = paths;
+            this.format = format;
+        }
+
+        /**
+         * Read from a stream.
+         */
+        public InternalBucket(StreamInput in) throws IOException {
+            key = in.readLong();
+            docCount = in.readLong();
+            aggregations = InternalAggregations.readAggregations(in);
+            level = in.readInt();
+            format = in.readNamedWriteable(DocValueFormat.class);
+            int pathsSize = in.readInt();
+            paths = new Long[pathsSize];
+            for (int i=0; i < pathsSize; i++) {
+                paths[i] = in.readLong();
+            }
+        }
+
+        /**
+         * Write to a stream.
+         */
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeLong(key);
+            out.writeLong(docCount);
+            aggregations.writeTo(out);
+            out.writeInt(level);
+            out.writeNamedWriteable(format);
+            out.writeInt(paths.length);
+            for (Long path: paths) {
+                out.writeLong(path);
+            }
+        }
+
+        @Override
+        public Object getKey() {
+            return key;
+        }
+
+        @Override
+        public String getKeyAsString() {
+            return format.format(key).toString();
+        }
+
+        @Override
+        public int compareKey(InternalBucket other) {
+            return Long.compare(key, other.key);
+        }
+
+        @Override
+        public long getDocCount() {
+            return docCount;
+        }
+
+        @Override
+        public Aggregations getAggregations() {
+            return aggregations;
+        }
+
+        /**
+         * Utility method of InternalDateHierarchy.doReduce()
+         */
+        InternalBucket reduce(List<InternalBucket> buckets, ReduceContext context) {
+            List<InternalAggregations> aggregationsList = new ArrayList<>(buckets.size());
+            InternalBucket reduced = null;
+            for (InternalBucket bucket : buckets) {
+                if (reduced == null) {
+                    reduced = bucket;
+                } else {
+                    reduced.docCount += bucket.docCount;
+                }
+                aggregationsList.add(bucket.aggregations);
+            }
+            reduced.aggregations = InternalAggregations.reduce(aggregationsList, context);
+            return reduced;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field(CommonFields.DOC_COUNT.getPreferredName(), docCount);
+            aggregations.toXContentInternal(builder, params);
+            builder.endObject();
+            return builder;
+        }
+    }
+
+
+    private List<InternalBucket> buckets;
+    private BucketOrder order;
+    private final int requiredSize;
+    private final int shardSize;
+    private final long otherHierarchyNodes;
+    private final long minDocCount;
+
+    public InternalDateHierarchy(
+            String name,
+            List<InternalBucket> buckets,
+            BucketOrder order,
+            long minDocCount,
+            int requiredSize,
+            int shardSize,
+            long otherHierarchyNodes,
+            List<PipelineAggregator> pipelineAggregators,
+            Map<String, Object> metaData
+    ) {
+        super(name, pipelineAggregators, metaData);
+        this.buckets = buckets;
+        this.order = order;
+        this.minDocCount = minDocCount;
+        this.requiredSize = requiredSize;
+        this.shardSize = shardSize;
+        this.otherHierarchyNodes = otherHierarchyNodes;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public InternalDateHierarchy(StreamInput in) throws IOException {
+        super(in);
+        order = InternalOrder.Streams.readOrder(in);
+        minDocCount = in.readVLong();
+        requiredSize = readSize(in);
+        shardSize = readSize(in);
+        otherHierarchyNodes = in.readVLong();
+        int bucketsSize = in.readInt();
+        this.buckets = new ArrayList<>(bucketsSize);
+        for (int i=0; i<bucketsSize; i++) {
+            this.buckets.add(new InternalBucket(in));
+        }
+    }
+
+    /**
+     * Write to a stream.
+     */
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        InternalOrder.Streams.writeOrder(order, out);
+        out.writeVLong(minDocCount);
+        writeSize(requiredSize, out);
+        writeSize(shardSize, out);
+        out.writeVLong(otherHierarchyNodes);
+        out.writeInt(buckets.size());
+        for (InternalBucket bucket: buckets) {
+            bucket.writeTo(out);
+        }
+    }
+
+    @Override
+    public String getWriteableName() {
+        return DateHierarchyAggregationBuilder.NAME;
+    }
+
+    protected int getShardSize() {
+        return shardSize;
+    }
+
+    public long getSumOtherHierarchyNodes() {
+        return otherHierarchyNodes;
+    }
+
+    @Override
+    public InternalDateHierarchy create(List<InternalBucket> buckets) {
+        return new InternalDateHierarchy(
+                this.name, buckets, order, minDocCount, requiredSize, shardSize, otherHierarchyNodes,
+                this.pipelineAggregators(), this.metaData);
+    }
+
+    @Override
+    public InternalBucket createBucket(InternalAggregations aggregations, InternalBucket prototype) {
+        return new InternalBucket(prototype.docCount, aggregations, prototype.key, prototype.level, prototype.paths, prototype.format);
+    }
+
+    @Override
+    public List<InternalBucket> getBuckets() {
+        return buckets;
+    }
+
+    /**
+     * Reduces the given aggregations to a single one and returns it.
+     */
+    @Override
+    public InternalDateHierarchy doReduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
+        Map<Long, List<InternalBucket>> buckets = null;
+        long otherHierarchyNodes = 0;
+
+        // extract buckets from aggregations
+        for (InternalAggregation aggregation : aggregations) {
+            InternalDateHierarchy dateHierarchy = (InternalDateHierarchy) aggregation;
+            if (buckets == null) {
+                buckets = new LinkedHashMap<>();
+            }
+
+            otherHierarchyNodes += dateHierarchy.getSumOtherHierarchyNodes();
+
+            for (InternalBucket bucket : dateHierarchy.buckets) {
+                List<InternalBucket> existingBuckets = buckets.get(bucket.key);
+                if (existingBuckets == null) {
+                    existingBuckets = new ArrayList<>(aggregations.size());
+                    buckets.put(bucket.key, existingBuckets);
+                }
+                existingBuckets.add(bucket);
+            }
+        }
+
+        // reduce and sort buckets depending of ordering rules
+        final int size = !reduceContext.isFinalReduce() ? buckets.size() : Math.min(requiredSize, buckets.size());
+        PathSortedTree<Long, InternalBucket> ordered = new PathSortedTree<>(order.comparator(null), size);
+        for (List<InternalBucket> sameTermBuckets : buckets.values()) {
+
+            final InternalBucket b = sameTermBuckets.get(0).reduce(sameTermBuckets, reduceContext);
+            if (b.getDocCount() >= minDocCount || !reduceContext.isFinalReduce()) {
+                reduceContext.consumeBucketsAndMaybeBreak(1);
+                ordered.add(b.paths, b);
+            } else {
+                reduceContext.consumeBucketsAndMaybeBreak(-countInnerBucket(b));
+            }
+        }
+
+        long sum_other_hierarchy_nodes = ordered.getFullSize() - size + otherHierarchyNodes;
+        return new InternalDateHierarchy(getName(), ordered.getAsList(), order, minDocCount, requiredSize, shardSize,
+                sum_other_hierarchy_nodes, pipelineAggregators(), getMetaData());
+    }
+
+    @Override
+    public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        Iterator<InternalBucket> bucketIterator = buckets.iterator();
+        builder.startArray(CommonFields.BUCKETS.getPreferredName());
+        InternalBucket prevBucket = null;
+        InternalBucket currentBucket = null;
+        while (bucketIterator.hasNext()) {
+            currentBucket = bucketIterator.next();
+
+            if (prevBucket != null) {
+                if (prevBucket.level == currentBucket.level) {
+                    builder.endObject();
+                } else if (prevBucket.level < currentBucket.level) {
+                    builder.startObject(name);
+                    builder.startArray(CommonFields.BUCKETS.getPreferredName());
+                } else {
+                    for (int i = currentBucket.level; i < prevBucket.level; i++) {
+                        builder.endObject();
+                        builder.endArray();
+                        builder.endObject();
+                    }
+                    builder.endObject();
+                }
+            }
+
+            builder.startObject();
+            builder.field(CommonFields.KEY.getPreferredName(), currentBucket.getKeyAsString());
+            builder.field(CommonFields.DOC_COUNT.getPreferredName(), currentBucket.docCount);
+            currentBucket.getAggregations().toXContentInternal(builder, params);
+
+            prevBucket = currentBucket;
+        }
+
+        if (currentBucket != null) {
+            for (int i=0; i < currentBucket.level; i++) {
+                builder.endObject();
+                builder.endArray();
+                builder.endObject();
+            }
+            builder.endObject();
+        }
+
+        builder.endArray();
+        return builder;
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(buckets, order, requiredSize, shardSize, otherHierarchyNodes, minDocCount);
+    }
+
+    @Override
+    protected boolean doEquals(Object obj) {
+        InternalDateHierarchy that = (InternalDateHierarchy) obj;
+        return Objects.equals(buckets, that.buckets)
+                && Objects.equals(order, that.order)
+                && Objects.equals(minDocCount, that.minDocCount)
+                && Objects.equals(requiredSize, that.requiredSize)
+                && Objects.equals(shardSize, that.shardSize)
+                && Objects.equals(otherHierarchyNodes, that.otherHierarchyNodes);
+    }
+}

--- a/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/PathHierarchyAggregationBuilder.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/PathHierarchyAggregationBuilder.java
@@ -1,5 +1,6 @@
 package org.opendatasoft.elasticsearch.search.aggregations.bucket;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -88,7 +89,7 @@ public class PathHierarchyAggregationBuilder extends ValuesSourceAggregationBuil
     }
 
     @Override
-    protected boolean serializeTargetValueType() {
+    protected boolean serializeTargetValueType(Version version) {
         return true;
     }
 
@@ -244,10 +245,10 @@ public class PathHierarchyAggregationBuilder extends ValuesSourceAggregationBuil
     }
 
     @Override
-    protected ValuesSourceAggregatorFactory<ValuesSource, ?> innerBuild(
+    protected ValuesSourceAggregatorFactory<ValuesSource> innerBuild(
             SearchContext context,
             ValuesSourceConfig<ValuesSource> config,
-            AggregatorFactory<?> parent,
+            AggregatorFactory parent,
             AggregatorFactories.Builder subFactoriesBuilder) throws IOException {
 
         if (minDepth > maxDepth)
@@ -301,12 +302,12 @@ public class PathHierarchyAggregationBuilder extends ValuesSourceAggregationBuil
      * Used for caching requests, amongst other things.
      */
     @Override
-    protected int innerHashCode() {
+    public int hashCode() {
         return Objects.hash(separator, minDepth, maxDepth, depth, order, minDocCount, bucketCountThresholds);
     }
 
     @Override
-    protected boolean innerEquals(Object obj) {
+    public boolean equals(Object obj) {
         PathHierarchyAggregationBuilder other = (PathHierarchyAggregationBuilder) obj;
         return Objects.equals(separator, other.separator)
                 && Objects.equals(minDepth, other.minDepth)

--- a/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/PathHierarchyAggregator.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/PathHierarchyAggregator.java
@@ -7,6 +7,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.BytesRefHash;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -255,4 +256,8 @@ public class PathHierarchyAggregator extends BucketsAggregator {
                 bucketCountThresholds.getShardSize(), 0, separator, pipelineAggregators(), metaData());
     }
 
+    @Override
+    protected void doClose() {
+        Releasables.close(bucketOrds);
+    }
 }

--- a/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/PathHierarchyAggregatorFactory.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/PathHierarchyAggregatorFactory.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * The factory of aggregators.
  * ValuesSourceAggregatorFactory extends {@link AggregatorFactory}
  */
-class PathHierarchyAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource, PathHierarchyAggregatorFactory> {
+class PathHierarchyAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource> {
 
     private BytesRef separator;
     private int minDepth;
@@ -50,7 +50,7 @@ class PathHierarchyAggregatorFactory extends ValuesSourceAggregatorFactory<Value
                                    long minDocCount,
                                    PathHierarchyAggregator.BucketCountThresholds bucketCountThresholds,
                                    SearchContext context,
-                                   AggregatorFactory<?> parent,
+                                   AggregatorFactory parent,
                                    AggregatorFactories.Builder subFactoriesBuilder,
                                    Map<String, Object> metaData
     ) throws IOException {

--- a/src/test/resources/rest-api-spec/test/PathHierarchy/30_date_hierarchy.yml
+++ b/src/test/resources/rest-api-spec/test/PathHierarchy/30_date_hierarchy.yml
@@ -1,0 +1,100 @@
+setup:
+  - do:
+      indices.create:
+        index: calendar
+        body:
+          settings:
+            number_of_shards: 2
+            number_of_replicas: 0
+          mappings:
+            properties:
+              date:
+                type: date
+
+  - do:
+      cluster.health:
+        wait_for_status: green
+
+---
+"Test with date hierarchy":
+  - do:
+      index:
+        index: calendar
+        id: 1
+        body: { "date": "2012-01-10T02:47:28" }
+
+  - do:
+      index:
+        index: calendar
+        id: 2
+        body: { "date": "2011-01-05T01:43:35" }
+
+  - do:
+      index:
+        index: calendar
+        id: 3
+        body: { "date": "2012-05-01T12:24:19" }
+
+  - do:
+      indices.refresh: {}
+
+
+# test years interval
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body: {
+          "size" : 0,
+          "aggs" : {
+            "tree" : {
+              "date_hierarchy" : {
+                "field" : "date",
+                "interval": "years",
+                "order": [{"_key": "asc"}],
+              }
+            }
+          }
+        }
+
+  - match: { hits.total: 3 }
+
+  - match: { aggregations.tree.buckets.0.key: "2011" }
+  - match: { aggregations.tree.buckets.0.doc_count: 1 }
+
+  - match: { aggregations.tree.buckets.1.key: "2012" }
+  - match: { aggregations.tree.buckets.1.doc_count: 2 }
+
+
+# test months interval
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body: {
+          "size": 0,
+          "aggs": {
+            "tree": {
+              "date_hierarchy": {
+                "field": "date",
+                "interval": "months",
+                "order": [{"_key": "asc"}],
+              }
+            }
+          }
+        }
+
+  - match: { hits.total: 3 }
+
+  - match: { aggregations.tree.buckets.0.key: "2011" }
+  - match: { aggregations.tree.buckets.0.doc_count: 1 }
+
+  - match: { aggregations.tree.buckets.1.key: "2012" }
+  - match: { aggregations.tree.buckets.1.doc_count: 2 }
+
+  - match: { aggregations.tree.buckets.0.tree.buckets.0.key: "01" }
+  - match: { aggregations.tree.buckets.0.tree.buckets.0.doc_count: 1 }
+
+  - match: { aggregations.tree.buckets.1.tree.buckets.0.key: "01" }
+  - match: { aggregations.tree.buckets.1.tree.buckets.0.doc_count: 1 }
+
+  - match: { aggregations.tree.buckets.1.tree.buckets.1.key: "05" }
+  - match: { aggregations.tree.buckets.1.tree.buckets.1.doc_count: 1 }

--- a/src/test/resources/rest-api-spec/test/PathHierarchy/30_date_hierarchy.yml
+++ b/src/test/resources/rest-api-spec/test/PathHierarchy/30_date_hierarchy.yml
@@ -7,9 +7,10 @@ setup:
             number_of_shards: 2
             number_of_replicas: 0
           mappings:
-            properties:
-              date:
-                type: date
+            _doc:
+              properties:
+                date:
+                  type: date
 
   - do:
       cluster.health:
@@ -20,18 +21,21 @@ setup:
   - do:
       index:
         index: calendar
+        type: _doc
         id: 1
         body: { "date": "2012-01-10T02:47:28" }
 
   - do:
       index:
         index: calendar
+        type: _doc
         id: 2
         body: { "date": "2011-01-05T01:43:35" }
 
   - do:
       index:
         index: calendar
+        type: _doc
         id: 3
         body: { "date": "2012-05-01T12:24:19" }
 
@@ -42,7 +46,6 @@ setup:
 # test years interval
   - do:
       search:
-        rest_total_hits_as_int: true
         body: {
           "size" : 0,
           "aggs" : {
@@ -68,7 +71,6 @@ setup:
 # test months interval
   - do:
       search:
-        rest_total_hits_as_int: true
         body: {
           "size": 0,
           "aggs": {


### PR DESCRIPTION
For an obscure reason, ./gradlew check doesn't work. Elasticsearch instance for integTests is not started (or not detected). It is maybe related to the (breaking change) of the pid file : https://www.elastic.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.4.html#deprecate-pidfile.
I cannot find any mention of that problem anywhere, but everything seems fine with the 7.2 branch.