### PR TITLE
Store Rounding.Prepared instead of recomputing it for each value

### DIFF
--- a/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregator.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregator.java
@@ -4,6 +4,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.Rounding;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -40,14 +41,14 @@ public class DateHierarchyAggregator extends BucketsAggregator {
                                    BucketOrder order,
                                    long minDocCount,
                                    BucketCountThresholds bucketCountThresholds,
-                                   List<DateHierarchyAggregationBuilder.RoundingInfo> roundingsInfo,
+                                   List<DateHierarchyAggregationBuilder.PreparedRounding> preparedRoundings,
                                    Aggregator parent,
                                    CardinalityUpperBound cardinalityUpperBound,
                                    Map<String,  Object> metadata
     ) throws IOException {
         super(name, factories, context, parent, cardinalityUpperBound, metadata);
         this.valuesSource = valuesSource;
-        this.roundingsInfo = roundingsInfo;
+        this.preparedRoundings = preparedRoundings;
         this.minDocCount = minDocCount;
         bucketOrds =  new BytesRefHash(1, context.bigArrays());
         this.bucketCountThresholds = bucketCountThresholds;
@@ -143,7 +144,7 @@ public class DateHierarchyAggregator extends BucketsAggregator {
     private final BucketOrder order;
     private final long minDocCount;
     private final BucketCountThresholds bucketCountThresholds;
-    private final List<DateHierarchyAggregationBuilder.RoundingInfo> roundingsInfo;
+    private final List<DateHierarchyAggregationBuilder.PreparedRounding> preparedRoundings;
     protected final Comparator<InternalPathHierarchy.InternalBucket> partiallyBuiltBucketComparator;
 
     /**
@@ -158,6 +159,7 @@ public class DateHierarchyAggregator extends BucketsAggregator {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
         final SortedNumericDocValues values = valuesSource.longValues(ctx);
+
         return new LeafBucketCollectorBase(sub, values) {
 
             @Override
@@ -169,11 +171,9 @@ public class DateHierarchyAggregator extends BucketsAggregator {
                     for (int i = 0; i < valuesCount; ++i) {
                         long value = values.nextValue();
                         String path = "";
-                        for (DateHierarchyAggregationBuilder.RoundingInfo roundingInfo: roundingsInfo) {
-                            // A little hacky: Add a microsecond to avoid collision between min dates interval
-                            // Since interval cannot be set to microsecond, it is not a problem
-                            long roundedValue = roundingInfo.rounding.round(value);
-                            path += roundingInfo.format.format(roundedValue).toString();
+                        for (DateHierarchyAggregationBuilder.PreparedRounding preparedRounding: preparedRoundings) {
+                            long roundedValue = preparedRounding.prepared.round(value);
+                            preparedRounding.roundingInfo.format.format(roundedValue).toString();
                             long bucketOrd = bucketOrds.add(new BytesRef(path));
                             if (bucketOrd < 0) { // already seen
                                 bucketOrd = -1 - bucketOrd;

--- a/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregator.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregator.java
@@ -173,7 +173,7 @@ public class DateHierarchyAggregator extends BucketsAggregator {
                         String path = "";
                         for (DateHierarchyAggregationBuilder.PreparedRounding preparedRounding: preparedRoundings) {
                             long roundedValue = preparedRounding.prepared.round(value);
-                            preparedRounding.roundingInfo.format.format(roundedValue).toString();
+                            path += preparedRounding.roundingInfo.format.format(roundedValue).toString();
                             long bucketOrd = bucketOrds.add(new BytesRef(path));
                             if (bucketOrd < 0) { // already seen
                                 bucketOrd = -1 - bucketOrd;

--- a/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregatorFactory.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/DateHierarchyAggregatorFactory.java
@@ -30,13 +30,13 @@ class DateHierarchyAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     private long minDocCount;
     private BucketOrder order;
-    private List<DateHierarchyAggregationBuilder.RoundingInfo> roundingsInfo;
+    private List<DateHierarchyAggregationBuilder.PreparedRounding> preparedRoundings;
     private final DateHierarchyAggregator.BucketCountThresholds bucketCountThresholds;
 
     DateHierarchyAggregatorFactory(String name,
                                    ValuesSourceConfig config,
                                    BucketOrder order,
-                                   List<DateHierarchyAggregationBuilder.RoundingInfo> roundingsInfo,
+                                   List<DateHierarchyAggregationBuilder.PreparedRounding> preparedRoundings,
                                    long minDocCount,
                                    DateHierarchyAggregator.BucketCountThresholds bucketCountThresholds,
                                    AggregationContext context,
@@ -46,7 +46,7 @@ class DateHierarchyAggregatorFactory extends ValuesSourceAggregatorFactory {
     ) throws IOException {
         super(name, config, context, parent, subFactoriesBuilder, metadata);
         this.order = order;
-        this.roundingsInfo = roundingsInfo;
+        this.preparedRoundings = preparedRoundings;
         this.minDocCount = minDocCount;
         this.bucketCountThresholds = bucketCountThresholds;
     }
@@ -99,7 +99,7 @@ class DateHierarchyAggregatorFactory extends ValuesSourceAggregatorFactory {
         bucketCountThresholds.ensureValidity();
         return new DateHierarchyAggregator(
                 name, factories, context, (ValuesSource.Numeric) config.getValuesSource(),
-                order, minDocCount, bucketCountThresholds, roundingsInfo, parent, cardinality, metadata);
+                order, minDocCount, bucketCountThresholds, preparedRoundings, parent, cardinality, metadata);
     }
 }
 


### PR DESCRIPTION
This PR should enhance speed performances of the DateHierarchyAggregator.

With timezones, sorting timestamps in buckets of different time units (year, month, etc.) is not an [easy problem](https://davecturner.github.io/2019/04/14/timezone-rounding.html).

The current implementation of the date hierarchy aggregator, involves an heavy computation for each time value.

This PR stores a "prepared" rounding for each time unit and reuse it for each time value.

Different strategies exist in `org.elasticsearch.common.Rounding` to prepare rounding of time units. I've used the `prepareForUnknown` since it is hard to know in advance which range of time values we may have.

This speeds thing up a lot.

Before this PR, a profiling of a date hierarchy aggregator gives the following (using Flight Recorder and a script to convert it to a flame graph):

![image](https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/assets/1618556/d3cde54c-708d-4122-9084-a5ddf81dae35)

We can see that rounding functions occupies most of the time.

After this PR:
![image](https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/assets/1618556/10899b60-7102-4b6f-912c-b1e1ce3dc769)

We can see that time rounding functions are not the ones that take most of the time anymore.

On a few local benchmarks I could observe something like a x3 on speed.