### PR TITLE
Prepare v7.17.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is a multi bucket aggregation.
 Installation
 ------------
 
-`bin/plugin --install path_hierarchy --url "https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.17.6.0/pathhierarchy-aggregation-7.17.6.0.zip"`
+`bin/plugin --install path_hierarchy --url "https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.17.6.1/pathhierarchy-aggregation-7.17.6.1.zip"`
 
 Build
 -----
@@ -309,7 +309,7 @@ Built with Java 17.
 The first 3 digits of plugin version is Elasticsearch versioning. The last digit is used for plugin versioning under an elasticsearch version.
 
 To install it, launch this command in Elasticsearch directory replacing the url with a release suiting your case (please check available releases [here](https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases)):
-`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.17.6.0/pathhierarchy-aggregation-7.17.6.0.zip`
+`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/releases/download/v7.17.6.1/pathhierarchy-aggregation-7.17.6.1.zip`
 
 
 License

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.6 AS elasticsearch-plugin-debug
 
-COPY /build/distributions/pathhierarchy-aggregation-7.17.6.0.zip /tmp/pathhierarchy-aggregation-7.17.6.0.zip
-RUN ./bin/elasticsearch-plugin install file:/tmp/pathhierarchy-aggregation-7.17.6.0.zip
+COPY /build/distributions/pathhierarchy-aggregation-7.17.6.1.zip /tmp/pathhierarchy-aggregation-7.17.6.1.zip
+RUN ./bin/elasticsearch-plugin install file:/tmp/pathhierarchy-aggregation-7.17.6.1.zip

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 es_version = 7.17.6
-plugin_version = 7.17.6.0
+plugin_version = 7.17.6.1


### PR DESCRIPTION
This release includes:
- Speed improvement of DateHierarchyAggregator https://github.com/opendatasoft/elasticsearch-aggregation-pathhierarchy/pull/29